### PR TITLE
Fix for GUI.NormaliseAngle()

### DIFF
--- a/SmartSASMod/GUI.cs
+++ b/SmartSASMod/GUI.cs
@@ -47,7 +47,7 @@ namespace SmartSASMod
             Vector2Int pos = SettingsManager.settings.windowPosition;
             Window window = Builder.CreateWindow(holder.transform, MainWindowID, 360, 290, pos.x, pos.y, true, true, 0.95f, "Smart SAS");
 
-            window.gameObject.GetComponent<DraggableWindowModule>().OnDropAction += () => 
+            window.gameObject.GetComponent<DraggableWindowModule>().OnDropAction += () =>
             {
                 SettingsManager.settings.windowPosition = Vector2Int.RoundToInt(window.Position);
                 SettingsManager.Save();
@@ -149,7 +149,7 @@ namespace SmartSASMod
             }
         }
 
-        public static float NormaliseAngle(float input) => ((input + 180f) % 360f) - 180f;
+        public static float NormaliseAngle(float input) => ((input + 540f) % 360f) - 180f;
 
         static void VerifyAngleInput(string input)
         {


### PR DESCRIPTION
had failed to normalise angles <-180 (-190->-190, should have been ->170)

Seems to prevent the spin causes by target and current direction being opposites sides ot the spin point