### PR TITLE
V1 7 darthan184

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.vs
 SmartSASMod/Dependencies
 SmartSASMod/bin
 SmartSASMod/obj

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-
 .DS_Store
+.vs
 SmartSASMod/Dependencies
 SmartSASMod/bin
 SmartSASMod/obj

--- a/SmartSASMod/GUI.cs
+++ b/SmartSASMod/GUI.cs
@@ -30,28 +30,47 @@ namespace SmartSASMod
             Vector2Int pos = SettingsManager.settings.windowPosition;
             Window window = Builder.CreateWindow(holder.transform, MainWindowID, 360, 290, pos.x, pos.y, true, true, 0.95f, "Smart SAS");
 
-            window.gameObject.GetComponent<DraggableWindowModule>().OnDropAction += () => 
+            window.CreateLayoutGroup(SFS.UI.ModGUI.Type.Vertical, UnityEngine.TextAnchor.MiddleCenter,10f);
+            window.gameObject.GetComponent<DraggableWindowModule>().OnDropAction += () =>
             {
                 SettingsManager.settings.windowPosition = Vector2Int.RoundToInt(window.Position);
                 SettingsManager.Save();
             };
 
-            buttons = new Dictionary<DirectionMode, SFS.UI.ModGUI.Button>
-            {
-                {DirectionMode.Prograde, Builder.CreateButton(window, 160, 50, -85, -25, () => ToggleDirection(DirectionMode.Prograde), "Prograde")},
-                {DirectionMode.Target, Builder.CreateButton(window, 160, 50, 85, -25, () => ToggleDirection(DirectionMode.Target), "Target")},
-                {DirectionMode.Surface, Builder.CreateButton(window, 160, 50, -85, -80, () => ToggleDirection(DirectionMode.Surface), "Surface")},
-                {DirectionMode.None, Builder.CreateButton(window, 160, 50, 85, -80, () => ToggleDirection(DirectionMode.None), "None")}
-            };
+            buttons = new Dictionary<DirectionMode, SFS.UI.ModGUI.Button>();
+
+            SFS.UI.ModGUI.Container buttonsTop_Container =  SFS.UI.ModGUI.Builder.CreateContainer(window);
+            buttonsTop_Container.CreateLayoutGroup(SFS.UI.ModGUI.Type.Horizontal, UnityEngine.TextAnchor.MiddleCenter,5f);
+            buttons.Add(DirectionMode.Prograde, Builder.CreateButton(buttonsTop_Container, 160, 50, 0,0, () => ToggleDirection(DirectionMode.Prograde), "Prograde"));
+            buttons.Add(DirectionMode.Target, Builder.CreateButton(buttonsTop_Container, 160, 50, 0, 0, () => ToggleDirection(DirectionMode.Target), "Target"));
+
+            SFS.UI.ModGUI.Container buttonsBottom_Container =  SFS.UI.ModGUI.Builder.CreateContainer(window);
+            buttonsBottom_Container.CreateLayoutGroup(SFS.UI.ModGUI.Type.Horizontal, UnityEngine.TextAnchor.MiddleCenter,5f);
+            buttons.Add(DirectionMode.Surface, Builder.CreateButton(buttonsBottom_Container, 160, 50, 0, 0, () => ToggleDirection(DirectionMode.Surface), "Surface"));
+            buttons.Add(DirectionMode.None, Builder.CreateButton(buttonsBottom_Container, 160, 50, 0, 0, () => ToggleDirection(DirectionMode.None), "None"));
 
             Builder.CreateLabel(window, 180, 50, 0, -145, "Angle Offset");
-            angleInput = Builder.CreateTextInput(window, 110, 50, 0, -200, "0.00");
+//~             angleInput = Builder.CreateTextInput(window, 110, 50, 0, -200, "0.00");
+//~             angleInput.field.onEndEdit.AddListener(VerifyOffsetInput);
+
+//~             Builder.CreateButton(window, 50, 50, -140, -200, () => AddOffsetValue(-10), "<<");
+//~             Builder.CreateButton(window, 50, 50, -85, -200, () => AddOffsetValue(-1), "<");
+//~             Builder.CreateButton(window, 50, 50, 140, -200, () => AddOffsetValue(10), ">>");
+//~             Builder.CreateButton(window, 50, 50, 85, -200, () => AddOffsetValue(1), ">");
+
+            SFS.UI.ModGUI.Container offset_Container =  SFS.UI.ModGUI.Builder.CreateContainer(window);
+            offset_Container.CreateLayoutGroup(SFS.UI.ModGUI.Type.Horizontal, UnityEngine.TextAnchor.MiddleCenter,5f);
+
+            Builder.CreateButton(offset_Container, 40, 30, 0, 0, () => AddOffsetValue(-90), "<<<");
+            Builder.CreateButton(offset_Container, 30, 30, 0, 0, () => AddOffsetValue(-10), "<<");
+            Builder.CreateButton(offset_Container, 30, 30, 0, 0, () => AddOffsetValue(-1), "<");
+
+            angleInput = Builder.CreateTextInput(offset_Container, 110, 50, 0, 0, "0.00");
             angleInput.field.onEndEdit.AddListener(VerifyOffsetInput);
 
-            Builder.CreateButton(window, 50, 50, -140, -200, () => AddOffsetValue(-10), "<<");
-            Builder.CreateButton(window, 50, 50, -85, -200, () => AddOffsetValue(-1), "<");
-            Builder.CreateButton(window, 50, 50, 140, -200, () => AddOffsetValue(10), ">>");
-            Builder.CreateButton(window, 50, 50, 85, -200, () => AddOffsetValue(1), ">");
+            Builder.CreateButton(offset_Container, 30, 30, 0, 0, () => AddOffsetValue(1), ">");
+            Builder.CreateButton(offset_Container, 30, 30, 0, 0, () => AddOffsetValue(10), ">>");
+            Builder.CreateButton(offset_Container, 40, 30, 0, 0, () => AddOffsetValue(90), ">>>");
 
             window.gameObject.transform.localScale = new Vector3(SettingsManager.settings.windowScale, SettingsManager.settings.windowScale, 1f);
 

--- a/SmartSASMod/Main.cs
+++ b/SmartSASMod/Main.cs
@@ -12,15 +12,15 @@ namespace SmartSASMod
 {
     public class Main : Mod
     {
-        public override string ModNameID => "smartsas";
-        public override string DisplayName => "Smart SAS";
-        public override string Author => "Astro The Rabbit";
+        public override string ModNameID => "smartsasdarth";
+        public override string DisplayName => "Smart SAS (Darthan Fork)";
+        public override string Author => "Astro The Rabbit, Darthan184";
         public override string MinimumGameVersionNecessary => "1.5.10.2";
-        public override string ModVersion => "1.7";
+        public override string ModVersion => "1.7-Darthan184-1";
         public override string Description => "Adds a variety of control options for the stability assist system (SAS).";
 
         public override Dictionary<string, string> Dependencies { get; } = new Dictionary<string, string> { { "UITools", "1.1.5" } };
-        public Dictionary<string, FilePath> UpdatableFiles => new Dictionary<string, FilePath>() { { "https://github.com/AstroTheRabbit/Smart-SAS-Mod-SFS/releases/latest/download/SmartSASMod.dll", new FolderPath(ModFolder).ExtendToFile("SmartSASMod.dll") } };
+//~         public Dictionary<string, FilePath> UpdatableFiles => new Dictionary<string, FilePath>() { { "https://github.com/AstroTheRabbit/Smart-SAS-Mod-SFS/releases/latest/download/SmartSASMod.dll", new FolderPath(ModFolder).ExtendToFile("SmartSASMod.dll") } };
 
         public static Mod mod;
         public static FolderPath modFolder;
@@ -44,7 +44,7 @@ namespace SmartSASMod
                     Assembly ANAISAssembly = Loader.main.GetLoadedMods().First(mod => mod.ModNameID == "ANAIS").GetType().Assembly;
                     Type velocityArrowPatch = ANAISAssembly.GetTypes().First(type => type.Name == "VelocityArrowDrawer_OnLocationChange_Patch");
                     ANAISTraverse = Traverse.Create(velocityArrowPatch);
-                } 
+                }
                 catch
                 {
                     Debug.Log("Smart SAS: ANAIS is not installed/active.");

--- a/SmartSASMod/Main.cs
+++ b/SmartSASMod/Main.cs
@@ -15,27 +15,27 @@ namespace SmartSASMod
         public override string ModNameID => "smartsasdarth";
         public override string DisplayName => "Smart SAS (Darthan Fork)";
         public override string Author => "Astro The Rabbit, Darthan184";
-        public override string MinimumGameVersionNecessary => "1.5.10.2";
-        public override string ModVersion => "1.7-Darthan184-1";
+        public override string MinimumGameVersionNecessary => "1.6.00.16";
+        public override string ModVersion => "1.7-Darthan184-2";
         public override string Description => "Adds a variety of control options for the stability assist system (SAS).";
 
-        public override Dictionary<string, string> Dependencies { get; } = new Dictionary<string, string> { { "UITools", "1.1.5" } };
+        public override Dictionary<string, string> Dependencies { get; } = new Dictionary<string, string> { { "UITools", "1.1.6" } };
 //~         public Dictionary<string, FilePath> UpdatableFiles => new Dictionary<string, FilePath>() { { "https://github.com/AstroTheRabbit/Smart-SAS-Mod-SFS/releases/latest/download/SmartSASMod.dll", new FolderPath(ModFolder).ExtendToFile("SmartSASMod.dll") } };
 
         public static Mod mod;
-        public static FolderPath modFolder;
+//~         public static FolderPath modFolder;
         public static Traverse ANAISTraverse = null;
 
         public override void Early_Load()
         {
             mod = this;
-            modFolder = new FolderPath(ModFolder);
+//~             modFolder = new FolderPath(ModFolder);
             new Harmony("smartsasmod").PatchAll();
         }
 
         public override void Load()
         {
-            SettingsManager.Load();
+            SettingsManager.Init();
             SceneHelper.OnWorldSceneLoaded += GUI.SpawnGUI;
             if (SettingsManager.settings.useANAISTargeting)
             {

--- a/SmartSASMod/Main.cs
+++ b/SmartSASMod/Main.cs
@@ -20,16 +20,13 @@ namespace SmartSASMod
         public override string Description => "Adds a variety of control options for the stability assist system (SAS).";
 
         public override Dictionary<string, string> Dependencies { get; } = new Dictionary<string, string> { { "UITools", "1.1.6" } };
-//~         public Dictionary<string, FilePath> UpdatableFiles => new Dictionary<string, FilePath>() { { "https://github.com/AstroTheRabbit/Smart-SAS-Mod-SFS/releases/latest/download/SmartSASMod.dll", new FolderPath(ModFolder).ExtendToFile("SmartSASMod.dll") } };
 
         public static Mod mod;
-//~         public static FolderPath modFolder;
         public static Traverse ANAISTraverse = null;
 
         public override void Early_Load()
         {
             mod = this;
-//~             modFolder = new FolderPath(ModFolder);
             new Harmony("smartsasmod").PatchAll();
         }
 

--- a/SmartSASMod/Main.cs
+++ b/SmartSASMod/Main.cs
@@ -12,14 +12,15 @@ namespace SmartSASMod
 {
     public class Main : Mod
     {
-        public override string ModNameID => "smartsasdarth";
-        public override string DisplayName => "Smart SAS (Darthan Fork)";
+        public override string ModNameID => "smartsas";
+        public override string DisplayName => "Smart SAS";
         public override string Author => "Astro The Rabbit, Darthan184";
         public override string MinimumGameVersionNecessary => "1.6.00.16";
-        public override string ModVersion => "1.7-Darthan184-2";
+        public override string ModVersion => "1.7";
         public override string Description => "Adds a variety of control options for the stability assist system (SAS).";
 
         public override Dictionary<string, string> Dependencies { get; } = new Dictionary<string, string> { { "UITools", "1.1.6" } };
+        public Dictionary<string, FilePath> UpdatableFiles => new Dictionary<string, FilePath>() { { "https://github.com/AstroTheRabbit/Smart-SAS-Mod-SFS/releases/latest/download/SmartSASMod.dll", new FolderPath(ModFolder).ExtendToFile("SmartSASMod.dll") } };
 
         public static Mod mod;
         public static Traverse ANAISTraverse = null;

--- a/SmartSASMod/Patches.cs
+++ b/SmartSASMod/Patches.cs
@@ -34,11 +34,11 @@ namespace SmartSASMod
                     float mass = __instance.rb2d.mass;
                     if (mass > 200f)
                         torque /= Mathf.Pow(mass / 200f, 0.35f);
-                    
+
                     float maxAcceleration = torque * Mathf.Rad2Deg / mass;
                     float stoppingTime = Mathf.Abs(angularVelocity / maxAcceleration);
                     float currentTime = Mathf.Abs(deltaAngle / angularVelocity);
-                    
+
                     if (stoppingTime > currentTime)
                     {
                         return Mathf.Sign(angularVelocity);
@@ -68,7 +68,7 @@ namespace SmartSASMod
                             SelectableObject target = __instance == rocket ? Map.navigation.target : sas.Target; // Keeps the last selected target if the sas comp.'s rocket isn't the currently controlled rocket.
                             if (Main.ANAISTraverse is Traverse traverse && __instance == rocket)
                             {
-                                if (traverse.Field("_navState").GetValue().ToString() == "ANAIS_TRANSFER_PLANNED")
+                                if (traverse.Field("_navState").GetValue().ToString() != "DEFAULT")
                                 {
                                     Double2 dv = traverse.Field<Double2>("_relativeVelocity").Value;
                                     targetRotation = GUI.NormaliseAngle((float)Math.Atan2(dv.y, dv.x) * Mathf.Rad2Deg);

--- a/SmartSASMod/Patches.cs
+++ b/SmartSASMod/Patches.cs
@@ -17,7 +17,7 @@ namespace SmartSASMod
             {
 
                 SASComponent sas = __instance.GetOrAddComponent<SASComponent>();
-                __instance.rb2d.angularDrag = 0.05f;
+                __instance.rb2d.angularDamping = 0.05f;
 
                 if (!WorldTime.main.realtimePhysics.Value || !__instance.hasControl.Value)
                     return result;
@@ -138,7 +138,7 @@ namespace SmartSASMod
                         return TargetRotationToTorque(targetRotation);
 
                     case DirectionMode.None:
-                        __instance.rb2d.angularDrag = 0;
+                        __instance.rb2d.angularDamping = 0;
                         return 0;
                 }
                 return result;

--- a/SmartSASMod/Settings.cs
+++ b/SmartSASMod/Settings.cs
@@ -16,41 +16,25 @@ namespace SmartSASMod
         public bool useANAISTargeting = true;
     }
 
-    public static class SettingsManager
+    public class SettingsManager : UITools.ModSettings<UserSettings>
     {
-        public static readonly FilePath Path = Main.modFolder.ExtendToFile("settings.txt");
-        static readonly FilePath oldPath = Main.modFolder.ExtendToFile("Config.txt");
-        public static UserSettings settings;
+        public static SettingsManager Main { get; private set; }
+        public static System.Action Save { get; private set; }
+
+        protected override SFS.IO.FilePath SettingsFile => new SFS.IO.FolderPath(SmartSASMod.Main.mod.ModFolder).ExtendToFile("Settings.txt");
+
         public static KeybindsManager keybindsManager;
 
-        public static void Load()
+        public static void Init()
         {
-            UserSettings oldSettings = null;
-            if (oldPath.FileExists())
-            {
-                if (!JsonWrapper.TryLoadJson(oldPath, out oldSettings))
-                {
-                    Debug.Log("Smart SAS: Converting old Config.txt to settings.txt.");
-                }
-                oldPath.DeleteFile();
-            }
-            else if (oldSettings == null && !JsonWrapper.TryLoadJson(Path, out settings) && Path.FileExists())
-            {
-                Debug.Log("Smart SAS: Settings file couldn't be loaded correctly or doesn't exist, reverting to defaults.");
-            }
-
-            settings = oldSettings ?? settings ?? new UserSettings();
-            Save();
-
+            Main = new SettingsManager();
             KeybindsManager.Setup();
-
+            Main.Initialize();
         }
 
-        public static void Save()
+        protected override void RegisterOnVariableChange(System.Action onChange)
         {
-            if (settings == null)
-                Load();
-            Path.WriteText(JsonWrapper.ToJson(settings, true));
+            UnityEngine.Application.quitting += Save = onChange;
         }
     }
 
@@ -137,7 +121,7 @@ namespace SmartSASMod
                 AddOnKeyDown_World(keybindsManager.Key_Target, () => GUI.ToggleDirection(DirectionMode.Target));
                 AddOnKeyDown_World(keybindsManager.Key_Surface, () => GUI.ToggleDirection(DirectionMode.Surface));
                 AddOnKeyDown_World(keybindsManager.Key_None, () => GUI.ToggleDirection(DirectionMode.None));
-                
+
                 AddOnKeyDown_World(keybindsManager.Key_Retrograde, () =>
                 {
                     GUI.SetDirection(DirectionMode.Prograde);

--- a/SmartSASMod/SmartSASMod.csproj
+++ b/SmartSASMod/SmartSASMod.csproj
@@ -6,18 +6,42 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="../../Other Files/Game Dependencies/*">
-      <HintPath>../../Other Files/Game Dependencies/*.dll</HintPath>
+    <Reference Include="0Harmony">
+      <HintPath>..\..\OtherFiles\GameDependancies\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\OtherFiles\GameDependancies\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\OtherFiles\GameDependancies\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="UITools">
-      <HintPath>../../Other Files/Mods Folder/UITools/UITools.dll</HintPath>
+      <HintPath>../../OtherFiles/ModsFolder/UITools/UITools.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>..\..\OtherFiles\GameDependancies\Unity.TextMeshPro.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.Physics2DModule">
+      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.Physics2DModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.TextRenderingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.UI.dll</HintPath>
     </Reference>
 
     <!-- The following DLLs cause warnings on build -->
-    <Reference Remove="**/System.IO.Compression.dll"/>
-    <Reference Remove="**/System.Net.Http.dll"/>
-    <Reference Remove="**/Firebase.*.dll"/>
-    <Reference Remove="**/Unity.Compat.dll"/>
-    <Reference Remove="**/Unity.Tasks.dll"/>
+    <Reference Remove="**/System.IO.Compression.dll" />
+    <Reference Remove="**/System.Net.Http.dll" />
+    <Reference Remove="**/Firebase.*.dll" />
+    <Reference Remove="**/Unity.Compat.dll" />
+    <Reference Remove="**/Unity.Tasks.dll" />
   </ItemGroup>
 </Project>

--- a/SmartSASMod/SmartSASMod.csproj
+++ b/SmartSASMod/SmartSASMod.csproj
@@ -6,42 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\OtherFiles\GameDependancies\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\OtherFiles\GameDependancies\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\OtherFiles\GameDependancies\Assembly-CSharp-firstpass.dll</HintPath>
+    <Reference Include="../../Other Files/Game Dependencies/*">
+      <HintPath>../../Other Files/Game Dependencies/*.dll</HintPath>
     </Reference>
     <Reference Include="UITools">
-      <HintPath>../../OtherFiles/ModsFolder/UITools/UITools.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\OtherFiles\GameDependancies\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.Physics2DModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.TextRenderingModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\OtherFiles\GameDependancies\UnityEngine.UI.dll</HintPath>
+      <HintPath>../../Other Files/Mods Folder/UITools/UITools.dll</HintPath>
     </Reference>
 
     <!-- The following DLLs cause warnings on build -->
-    <Reference Remove="**/System.IO.Compression.dll" />
-    <Reference Remove="**/System.Net.Http.dll" />
-    <Reference Remove="**/Firebase.*.dll" />
-    <Reference Remove="**/Unity.Compat.dll" />
-    <Reference Remove="**/Unity.Tasks.dll" />
+    <Reference Remove="**/System.IO.Compression.dll"/>
+    <Reference Remove="**/System.Net.Http.dll"/>
+    <Reference Remove="**/Firebase.*.dll"/>
+    <Reference Remove="**/Unity.Compat.dll"/>
+    <Reference Remove="**/Unity.Tasks.dll"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Amended ANAIS targeting to follow all ANAIS velocity arrows, not just orbit change. This allows SAS to make use of ANAIS velocity arrows when approaching the target to martch my latest update to Thrust Assist.

Added large step (+/- 90 deg) buttons. This enables the switch from prograde to retrograde in just two clicks (as opposed to 18). It also allows 90 or -90 deg to be reached quickly from 0. I've found that these angles seem to be the most commonly used. Note - I did not amend add shortcut keys for these.